### PR TITLE
Fix build error by removing duplicate type.

### DIFF
--- a/bchain/types.go
+++ b/bchain/types.go
@@ -182,10 +182,6 @@ type TransactionReceipt struct {
 	ContractAddress string `json:"contractAddress"`
 }
 
-type TransactionReceipt struct {
-	ContractAddress string `json:"contractAddress"`
-}
-
 // RPCError defines rpc error returned by backend
 type RPCError struct {
 	Code    int    `json:"code"`
@@ -298,9 +294,9 @@ type BlockChain interface {
 	EthereumTypeEstimateGas(params map[string]interface{}) (uint64, error)
 	EthereumTypeGetErc20ContractInfo(contractDesc AddressDescriptor) (*Erc20Contract, error)
 	EthereumTypeGetErc20ContractBalance(addrDesc, contractDesc AddressDescriptor) (*big.Int, error)
-	EthereumTypeGetReceipt(txid string)(*TransactionReceipt, error)
+	EthereumTypeGetReceipt(txid string) (*TransactionReceipt, error)
 	// BSC specific
-	BscTypeGetTokenHub()(*Tokenhub, error)
+	BscTypeGetTokenHub() (*Tokenhub, error)
 }
 
 // BlockChainParser defines common interface to parsing and conversions of block chain data


### PR DESCRIPTION
There was a duplicate type declaration which led to a build error:

```
go: downloading golang.org/x/net v0.0.0-20200625001655-4c5254603344
make[2]: Leaving directory '/build/build/pkg-defs/blockbook'
cd /go/src/github.com/trezor/blockbook && packr clean && packr
cd /go/src/github.com/trezor/blockbook && go build -o /build/build/pkg-defs/blockbook/blockbook -ldflags="-s -w -X github.com/trezor/blockbook/common.version=0.3.4 -X github.com/trezor/blockbook/common.gitcommit=a93de7e -X github.com/trezor/blockbook/common.buildtime=2021-05-18T18:51:25+00:00"
# github.com/trezor/blockbook/bchain
bchain/types.go:185:6: TransactionReceipt redeclared in this block
	previous declaration at bchain/types.go:181:6
Makefile:14: recipe for target 'build' failed
make[1]: *** [build] Error 2
make[1]: Leaving directory '/build/build/pkg-defs/blockbook'
dh_auto_build: make -j1 returned exit code 2
debian/rules:6: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
make: *** [deb-bsc] Error 2
```