### PR TITLE
Update Dockerfile correct the goLang version for build (avoid can not found embed package in go)

### DIFF
--- a/build/docker/bin/Dockerfile
+++ b/build/docker/bin/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
                        liblz4-dev graphviz && \
     apt-get clean
 
-ENV GOLANG_VERSION=go1.14.2.linux-amd64
+ENV GOLANG_VERSION=go1.16.10.linux-amd64
 ENV ROCKSDB_VERSION=v5.18.3
 ENV GOPATH=/go
 ENV PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
If you dont update go version - you can not build because go version 1.14 not included embed package