### PR TITLE
Fix crash on transaction 0x2e89f1dcb911d9d460c3ce4de2499e12090bffcb11119eac19bed8c7d6850e94

### DIFF
--- a/bchain/coins/bsc/erc20.go
+++ b/bchain/coins/bsc/erc20.go
@@ -415,9 +415,13 @@ func parseErc20StringProperty(contractDesc bchain.AddressDescriptor, data string
 		if n != nil {
 			l := n.Uint64()
 			if l > 0 && 2*int(l) <= len(data)-128 {
-				b, err := hex.DecodeString(data[128 : 128+2*l])
-				if err == nil {
-					return string(b)
+				start := 128
+				end := 128+2*l
+				if end < uint64(len(data)) {
+					b, err := hex.DecodeString(data[start : end])
+					if err == nil {
+						return string(b)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix crash on transaction https://bscscan.com/tx/0x2e89f1dcb911d9d460c3ce4de2499e12090bffcb11119eac19bed8c7d6850e94

The error log:
```
I1116 14:05:11.876792 1412350 rocksdb_ethereumtype.go:212] tx 0x2e89f1dcb911d9d460c3ce4de2499e12090bffcb11119eac19bed8c7d6850e94 create new contract 0xB50A128438F91252E97f7AE78469C0b5E6153d0f
I1116 14:05:11.876820 1412350 rocksdb.go:512] 1 contracts created in block 12585082
I1116 14:05:12.538196 1412350 rocksdb.go:312] rocksdb: close
E1116 14:05:12.538647 1412350 blockbook.go:117] main recovered from panic: runtime error: slice bounds out of range [:12196040594413952182] with length 384
goroutine 1 [running]:
runtime/debug.Stack(0x75, 0x0, 0x0)
        /opt/go/src/runtime/debug/stack.go:24 +0x9d
runtime/debug.PrintStack()
        /opt/go/src/runtime/debug/stack.go:16 +0x22
main.main.func1()
        /go/src/github.com/trezor/blockbook/blockbook.go:118 +0xba
panic(0x137ac00, 0xc000195b20)
        /opt/go/src/runtime/panic.go:969 +0x166
github.com/trezor/blockbook/bchain/coins/bsc.parseErc20StringProperty(0xc014613830, 0x14, 0x30, 0xc0003f01a0, 0x182, 0xc0003f01a0, 0x182)
        /go/src/github.com/trezor/blockbook/bchain/coins/bsc/erc20.go:418 +0x534
github.com/trezor/blockbook/bchain/coins/bsc.(*EthereumRPC).EthereumTypeGetErc20ContractInfo(0xc00043ea20, 0xc014613830, 0x14, 0x30, 0x28, 0x30, 0xc014613830)
        /go/src/github.com/trezor/blockbook/bchain/coins/bsc/erc20.go:472 +0x327
github.com/trezor/blockbook/bchain/coins.(*blockChainWithMetrics).EthereumTypeGetErc20ContractInfo(0xc00000e100, 0xc014613830, 0x14, 0x30, 0x0, 0x0, 0x0)
        /go/src/github.com/trezor/blockbook/bchain/coins/blockchain.go:312 +0xd4
github.com/trezor/blockbook/db.(*RocksDB).storeNewERC20Contracts(0xc000246000, 0xc013fecf98, 0xc014249480, 0x1, 0x1, 0x2, 0x2)
        /go/src/github.com/trezor/blockbook/db/rocksdb_ethereumtype.go:60 +0xe5
github.com/trezor/blockbook/db.(*RocksDB).ConnectBlock(0xc000246000, 0xc0002442a0, 0x0, 0x0)
        /go/src/github.com/trezor/blockbook/db/rocksdb.go:514 +0x583
github.com/trezor/blockbook/db.(*SyncWorker).connectBlocks.func1(0xc0002442a0, 0x0, 0x0, 0x1, 0xc000041301)
        /go/src/github.com/trezor/blockbook/db/sync.go:189 +0x8a
github.com/trezor/blockbook/db.(*SyncWorker).connectBlocks(0xc00009e600, 0x0, 0xc00003e801, 0x0, 0x0)
        /go/src/github.com/trezor/blockbook/db/sync.go:214 +0x256
github.com/trezor/blockbook/db.(*SyncWorker).resyncIndex(0xc00009e600, 0x0, 0x229f801, 0x7fff00000010, 0x15cb500)
        /go/src/github.com/trezor/blockbook/db/sync.go:144 +0x473
github.com/trezor/blockbook/db.(*SyncWorker).ResyncIndex(0xc00009e600, 0x0, 0x1, 0xc0002048c0, 0xc000306690)
        /go/src/github.com/trezor/blockbook/db/sync.go:57 +0x90
main.mainWithExitCode(0x0)
        /go/src/github.com/trezor/blockbook/blockbook.go:290 +0x1b6b
main.main()
        /go/src/github.com/trezor/blockbook/blockbook.go:122 +0x44
```

This PR requires https://github.com/binance-chain/blockbook-bsc/pull/6 to build.